### PR TITLE
Changed recipe, bulk and mass of Phosphate

### DIFF
--- a/Patches/Vanilla Weapons Expanded/Ammo/FireExtinguisher.xml
+++ b/Patches/Vanilla Weapons Expanded/Ammo/FireExtinguisher.xml
@@ -54,8 +54,8 @@
                 <MarketValue>0.50</MarketValue>
                 <MaxHitPoints>70</MaxHitPoints>
                 <Flammability>1.0</Flammability>
-                <Mass>0.05</Mass>
-                <Bulk>0.1</Bulk>
+                <Mass>0.03</Mass>
+                <Bulk>0.03</Bulk>
               </statBases>
               <tradeTags>
                 <li>CE_AutoEnableTrade</li>
@@ -64,7 +64,7 @@
               <thingCategories>
                 <li>AmmoVWEExtinguisher</li>
               </thingCategories>
-              <stackLimit>400</stackLimit>
+              <stackLimit>500</stackLimit>
               <ammoClass>FoamFuel</ammoClass>
               <generateAllowChance>0</generateAllowChance>
             </ThingDef>
@@ -120,8 +120,8 @@
           <value>
             <RecipeDef ParentName="ExtinguisherAmmoRecipeBase">
               <defName>MakeAmmo_VWE_Extinguisher</defName>
-              <label>make phosphate x400</label>
-              <description>Craft 400 units of Phosphate.</description>
+              <label>make phosphate x500</label>
+              <description>Craft 500 units of Phosphate.</description>
               <jobString>Making Phosphate.</jobString>
               <ingredients>
                 <li>


### PR DESCRIPTION
## Additions

- None.

## Changes

- Changed the bulk and mass of the Phosphate ammo, keeping it with the standard fire extinguisher weight of around 14 kilograms when it's full. Made it coherent so bulk = mass.
- Changed the recipe to 500 phosphate units, to match the magazine size of the Fire Extinguisher.


## References

None

## Reasoning

- Fire Extinguisher had a tremendous weight and bulk, that made any reasonable pawn only be able to load 360 phosphate units into the fire extinguisher.

## Alternatives

- ¿Reduce maximum magazine size for the Fire Extinguisher?

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [Unnecesary] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony for 1 In-Game Year.
