### PR TITLE
Goliath Ammo fix

### DIFF
--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Goliath.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Goliath.xml
@@ -36,6 +36,8 @@
 			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="AA_Goliath"]/statBases</xpath>
 				<value>
+					<CarryWeight>400</CarryWeight>
+			                <CarryBulk>1000</CarryBulk>
 					<AimingAccuracy>1.0</AimingAccuracy>
 			                <ShootingAccuracyPawn>1</ShootingAccuracyPawn>
 					<MeleeDodgeChance>0.01</MeleeDodgeChance>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Goliath.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Goliath.xml
@@ -22,7 +22,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_Goliath"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>14</ArmorRating_Blunt>
+					<ArmorRating_Blunt>17</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">


### PR DESCRIPTION
Important change which allows goliath to spawn with ammo.

