### PR TITLE
Update AlphaAnimals_CE_Patch_VerbShootCE.xml

### DIFF
--- a/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_VerbShootCE.xml
+++ b/Patches/Alpha Animals/ThingDefs_Misc/AlphaAnimals_CE_Patch_VerbShootCE.xml
@@ -32,11 +32,11 @@
 										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 											<hasStandardCommand>true</hasStandardCommand>
 											<defaultProjectile>AA_PoisonBolt</defaultProjectile>
-											<warmupTime>2</warmupTime>
+											<warmupTime>1.75</warmupTime>
 											<burstShotCount>1</burstShotCount>
 											<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-											<minRange>2</minRange>
-											<range>20</range>
+											<minRange>12</minRange>
+											<range>24</range>
 											<soundCast>AA_PoisonBolt</soundCast>
 											<muzzleFlashScale>0</muzzleFlashScale>
 											<commonality>0.8</commonality>
@@ -53,11 +53,11 @@
 										<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 											<hasStandardCommand>true</hasStandardCommand>
 											<defaultProjectile>AA_PoisonBolt</defaultProjectile>
-											<warmupTime>1.5</warmupTime>
+											<warmupTime>1.25</warmupTime>
 											<burstShotCount>1</burstShotCount>
 											<ticksBetweenBurstShots>2</ticksBetweenBurstShots>
-											<minRange>2</minRange>
-											<range>30</range>
+											<minRange>12</minRange>
+											<range>36</range>
 											<soundCast>AA_PoisonBolt</soundCast>
 											<muzzleFlashScale>0</muzzleFlashScale>
 											<commonality>0.8</commonality>


### PR DESCRIPTION
Range adjustments for black hive creatures, note that the minimum range is there to encourage them to use melee at close range, as of now they display a strange behavior of fleeing when shot at longer ranges and using its range attack exclusively. Need more testing atm.