### PR TITLE
Update AlphaAnimals_CE_Patch_Race_Black_Hive.xml

### DIFF
--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Black_Hive.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Black_Hive.xml
@@ -56,9 +56,9 @@
 								<li>Bite</li>
 							</capacities>
 							<power>9</power>
-							<cooldownTime>1.4</cooldownTime>
+							<cooldownTime>1.33</cooldownTime>
 							<linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
-							<armorPenetrationSharp>0.45</armorPenetrationSharp>
+							<armorPenetrationSharp>0.5</armorPenetrationSharp>
 							<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
 						</li>
 						<li Class="CombatExtended.ToolCE">
@@ -114,6 +114,13 @@
 					<combatPower>60</combatPower>
 				</value>
 			</li>
+				
+			<li Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede"]/race/baseHealthScale</xpath>
+				<value>
+					<baseHealthScale>1.6</baseHealthScale>
+				</value>
+			</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede"]/tools</xpath>
@@ -124,7 +131,7 @@
 							<capacities>
 								<li>Cut</li>
 							</capacities>
-							<power>21</power>
+							<power>22</power>
 							<cooldownTime>1.68</cooldownTime>
 							<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
 							<armorPenetrationSharp>1</armorPenetrationSharp>
@@ -154,11 +161,18 @@
 					</li>
 				</value>
 			</li>
+				
+				<li Class="PatchOperationReplace">
+					<xpath>/Defs/ThingDef[defName="AA_BlackSpider"]/race/baseHealthScale</xpath>
+					<value>
+						<baseHealthScale>2.5</baseHealthScale>
+					</value>
+				</li>
 
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_BlackSpider"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>13</ArmorRating_Blunt>
+					<ArmorRating_Blunt>12</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -193,7 +207,7 @@
 							<capacities>
 								<li>Cut</li>
 							</capacities>
-							<power>30</power>
+							<power>32</power>
 							<cooldownTime>2.1</cooldownTime>
 							<linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
 							<armorPenetrationSharp>40</armorPenetrationSharp>

--- a/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Black_Hive.xml
+++ b/Patches/Alpha Animals/ThingDefs_Races/AlphaAnimals_CE_Patch_Race_Black_Hive.xml
@@ -118,7 +118,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>/Defs/ThingDef[defName="AA_BlackSpelopede"]/race/baseHealthScale</xpath>
 				<value>
-					<baseHealthScale>1.6</baseHealthScale>
+					<baseHealthScale>1.5</baseHealthScale>
 				</value>
 			</li>
 
@@ -165,7 +165,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>/Defs/ThingDef[defName="AA_BlackSpider"]/race/baseHealthScale</xpath>
 					<value>
-						<baseHealthScale>2.5</baseHealthScale>
+						<baseHealthScale>2.1</baseHealthScale>
 					</value>
 				</li>
 


### PR DESCRIPTION
The health of black hive creatures nerfed to match vanilla insectoids, they still have noticeably more health than regular counterparts even after the nerf. No, I'm not trying to make these creatures 'not a threat' or whatever, all basic insectoids have their health nerfed in CE to account for the significant armor buff they gain. It is to make them less bullet spongy.